### PR TITLE
Fix: Ardunio Mega2560 pins and build type

### DIFF
--- a/ci/platformio.ini
+++ b/ci/platformio.ini
@@ -24,7 +24,7 @@ build_flags = -Werror -Wall
 
 [env:atmega2560]
 platform    = atmelavr
-board       = ATmega2560
+board       = megaatmega2560
 framework   = arduino
 build_flags = -Werror -Wall
 

--- a/src/StepperISR_avr.cpp
+++ b/src/StepperISR_avr.cpp
@@ -2,7 +2,7 @@
 #include "StepperISR.h"
 
 #if defined(ARDUINO_ARCH_AVR)
-#if !(defined(ARDUINO_AVR_NANO) || defined(ARDUINO_AVR_ATmega2560))
+#if !(defined(ARDUINO_AVR_NANO) || defined(ARDUINO_AVR_MEGA2560))
 #error "Unsupported board"
 #endif
 #if !(defined(__AVR_ATmega328P__) || defined(__AVR_ATmega2560__))

--- a/src/StepperISR_avr.cpp
+++ b/src/StepperISR_avr.cpp
@@ -14,7 +14,7 @@
 #if defined(ARDUINO_AVR_NANO)
 #define stepPinStepper1A 9  /* OC1A */
 #define stepPinStepper1B 10 /* OC1B */
-#elif defined(ARDUINO_AVR_ATmega2560)
+#elif defined(ARDUINO_AVR_MEGA2560)
 #define stepPinStepper1A 11 /* OC1A */
 #define stepPinStepper1B 12 /* OC1B */
 #define stepPinStepper1C 13 /* OC1B */

--- a/src/StepperISR_avr.cpp
+++ b/src/StepperISR_avr.cpp
@@ -15,18 +15,18 @@
 #define stepPinStepper1A 9  /* OC1A */
 #define stepPinStepper1B 10 /* OC1B */
 #elif defined(ARDUINO_AVR_ATmega2560)
-#define stepPinStepper1A 24 /* OC1A */
-#define stepPinStepper1B 25 /* OC1B */
-#define stepPinStepper1C 26 /* OC1B */
+#define stepPinStepper1A 11 /* OC1A */
+#define stepPinStepper1B 12 /* OC1B */
+#define stepPinStepper1C 13 /* OC1B */
 #define stepPinStepper3A 5  /* OC3A */
-#define stepPinStepper3B 6  /* OC3B */
-#define stepPinStepper3C 7  /* OC3C */
-#define stepPinStepper4A 15 /* OC4A */
-#define stepPinStepper4B 16 /* OC4B */
-#define stepPinStepper4C 17 /* OC4C */
-#define stepPinStepper5A 38 /* OC5A */
-#define stepPinStepper5B 39 /* OC5B */
-#define stepPinStepper5C 40 /* OC5C */
+#define stepPinStepper3B 2  /* OC3B */
+#define stepPinStepper3C 3  /* OC3C */
+#define stepPinStepper4A 6 /* OC4A */
+#define stepPinStepper4B 7 /* OC4B */
+#define stepPinStepper4C 8 /* OC4C */
+#define stepPinStepper5A 46 /* OC5A */
+#define stepPinStepper5B 45 /* OC5B */
+#define stepPinStepper5C 44 /* OC5C */
 #endif
 
 #if defined(__AVR_ATmega328P__)


### PR DESCRIPTION
The pins were mapped to the atMega2560 IC pins,
instead of the arduino/wiring pinout.