### PR TITLE
Gagank1/esp idf component

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,6 @@
+idf_component_register(
+    SRC_DIRS "src"
+    INCLUDE_DIRS "src"
+    REQUIRES arduino
+    PRIV_REQUIRES driver soc 
+)

--- a/src/RampGenerator.cpp
+++ b/src/RampGenerator.cpp
@@ -250,7 +250,7 @@ static void _getNextCommand(const struct ramp_ro_s *ramp,
     } else {
       need_count_up = delta > 0;
     }
-    remaining_steps = abs(delta);
+    remaining_steps = abs((int) delta);
   }
 
   // If not moving, then use requested direction
@@ -466,7 +466,7 @@ static void _getNextCommand(const struct ramp_ro_s *ramp,
 #endif
   // Number of steps to execute with limitation to min 1 and max remaining steps
   uint16_t steps = planning_steps;
-  steps = min(steps, abs(remaining_steps));  // This could be problematic
+  steps = min(steps, abs((int) remaining_steps));  // This could be problematic
   steps = max(steps, 1);
   steps = min(255, steps);
 


### PR DESCRIPTION
I added a CMakeLists.txt file to allow easy integration as an ESP-IDF component.

The compiler threw some ambiguity errors with the call to abs() due to multiple definitions. Casting to int fixes in the call fixes this.

Tested on PlatformIO Espressif32 Platform v3.3.0