### PR TITLE
Increase task stack size

### DIFF
--- a/src/StepperISR_esp32.cpp
+++ b/src/StepperISR_esp32.cpp
@@ -126,7 +126,7 @@ void StepperQueue::adjustSpeedToStepperCount(uint8_t steppers) {
 }
 
 void fas_init_engine(FastAccelStepperEngine *engine, uint8_t cpu_core) {
-#define STACK_SIZE 1000
+#define STACK_SIZE 2000
 #define PRIORITY configMAX_PRIORITIES
   if (cpu_core > 1) {
     xTaskCreate(StepperTask, "StepperTask", STACK_SIZE, engine, PRIORITY, NULL);


### PR DESCRIPTION
This increases the size of the stack allocated for StepperTask because it has been observed to overflow its stack when `setExternalCallForPin` is used.

[Tracing the free stack space](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/freertos.html?highlight=highwatermark#_CPPv412vTaskGetInfo12TaskHandle_tP12TaskStatus_t10BaseType_t10eTaskState) indicates that the approximate stack space used:
- 8 steppers, no `setExternalCallForPin`: 748 bytes
- 8 steppers, `setExternalCallForPin`: 1092 bytes

I've just arbitrarily doubled the stack size since the ESP32 has a significant amount of RAM available, though it might be good to consider if we can set this more intelligently.