### PR TITLE
ESP32 S3 MCPWM/PCNT Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,12 @@ Comments to pin sharing:
 * supports up to four stepper motors using Step/Direction/Enable Control (Direction and Enable is optional)
 * Steppers' command queue depth: 32
 
+### ESP32S3
+
+* allows up to 200000 generated steps per second ?
+* supports up to four stepper motors using Step/Direction/Enable Control (Direction and Enable is optional)
+* Steppers' command queue depth: 32
+
 ### Atmel SAM Due
 
 * allows up to 50000 generated steps per second
@@ -267,6 +273,10 @@ As of now, allocation of steppers on esp32 are: first all 6 mcpwm/pcnt drivers a
 ### ESP32S2
 
 This stepper driver uses rmt module.
+
+### ESP32S3
+
+This stepper driver uses mcpwm/pcnt modules. Can drive up to 4 motors. Tested with 2 motors.
 
 ### ESP32C3/ESP32-MINI-1
 

--- a/src/common.h
+++ b/src/common.h
@@ -130,6 +130,27 @@ struct queue_end_s {
 
 //==========================================================================
 //
+// ESP32 derivate - ESP32S3 - NOT SUPPORTED
+//
+//==========================================================================
+#elif CONFIG_IDF_TARGET_ESP32S3
+#define SUPPORT_ESP32_MCPWM_PCNT
+#include <driver/mcpwm.h>
+#include <driver/pcnt.h>
+#include <soc/mcpwm_reg.h>
+#include <soc/mcpwm_struct.h>
+#include <soc/pcnt_reg.h>
+#include <soc/pcnt_struct.h>
+
+#include <driver/rmt.h>
+#define QUEUES_MCPWM_PCNT 4
+#define QUEUES_RMT 0
+
+// have support for pulse counter
+#define SUPPORT_ESP32_PULSE_COUNTER
+
+//==========================================================================
+//
 // ESP32 derivate - ESP32C3 - NOT SUPPORTED
 //
 //==========================================================================


### PR DESCRIPTION
This changes allow support for ESP32 S3 using MCPWM/PCNT.

I believe it can support up to 4 motors, but only tested with 2 motors simultaneously.