### PR TITLE
Support ATmega168, ATmega168P, and ATmega328

### DIFF
--- a/.github/workflows/build_examples_nanoatmega168.yml
+++ b/.github/workflows/build_examples_nanoatmega168.yml
@@ -1,0 +1,21 @@
+name: Build examples for Atmega168
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Make directories
+      run: bash extras/scripts/build-pio-dirs.sh
+    - name: Build on PlatformIO
+      run: bash extras/scripts/build-platformio.sh nanoatmega168
+

--- a/README.md
+++ b/README.md
@@ -20,15 +20,15 @@ No issue with platformio. Check the [related issue](https://github.com/arduino/l
 [![Build examples for esp32arduino @ latest](https://github.com/gin66/FastAccelStepper/actions/workflows/build_examples_esp32arduinolatest.yml/badge.svg)](https://github.com/gin66/FastAccelStepper/actions/workflows/build_examples_esp32arduinolatest.yml)
 [![Build examples for Atmega2560](https://github.com/gin66/FastAccelStepper/actions/workflows/build_examples_atmega2560.yml/badge.svg)](https://github.com/gin66/FastAccelStepper/actions/workflows/build_examples_atmega2560.yml)
 [![Build examples for Atmel SAM](https://github.com/gin66/FastAccelStepper/actions/workflows/build_examples_atmelsam.yml/badge.svg)](https://github.com/gin66/FastAccelStepper/actions/workflows/build_examples_atmelsam.yml)
-[![Build examples for Atmega328](https://github.com/gin66/FastAccelStepper/actions/workflows/build_examples_nanoatmega328.yml/badge.svg)](https://github.com/gin66/FastAccelStepper/actions/workflows/build_examples_nanoatmega328.yml)
+[![Build examples for Atmega168/328](https://github.com/gin66/FastAccelStepper/actions/workflows/build_examples_nanoatmega328.yml/badge.svg)](https://github.com/gin66/FastAccelStepper/actions/workflows/build_examples_nanoatmega328.yml)
 [![Build examples for Atmega32U4](https://github.com/gin66/FastAccelStepper/actions/workflows/build_examples_atmega32u4.yml/badge.svg)](https://github.com/gin66/FastAccelStepper/actions/workflows/build_examples_nanoatmega32u4.yml)
 
 This is a high speed alternative for the [AccelStepper library](http://www.airspayce.com/mikem/arduino/AccelStepper/).
-Supported are avr (ATmega 328, ATmega2560,  ATmega32u4), esp32, esp32s2, esp32s3 and atmelsam due.
+Supported are avr (ATmega 168/328/P, ATmega2560,  ATmega32u4), esp32, esp32s2, esp32s3 and atmelsam due.
 
 The stepper motors should be connected via a driver IC (like A4988) with a 1, 2 or 3-wire connection:
 * Step Signal
-	- avr atmega328p: only Pin 9 and 10.
+	- avr atmega168/328/p: only Pin 9 and 10.
 	- avr atmega32u4: only Pin 9, 10 and 11.
 	- avr atmega2560: only Pin 6, 7 and 8.
       On platformio, this can be changed to other triples: 11/12/13 Timer 1, 5/2/3 Timer 3 or 46/45/44 Timer 5 with FAS_TIMER_MODULE setting.
@@ -104,7 +104,7 @@ Comments to pin sharing:
   Every motor will adhere to its auto enable delay, even if other motors already have enabled the pin.
 * Direction pin sharing: The direction pin will be exclusively driven by one motor. If one motor is operating, another motor will wait until the direction pin comes available
 
-### AVR ATMega 328
+### AVR ATMega 168/168P/328/328P
 
 * allows up to 50000 generated steps per second for single stepper operation, 37000 for dual stepper
 * supports up to two stepper motors using Step/Direction/Enable Control (Direction and Enable is optional)
@@ -224,7 +224,7 @@ Few comments to auto enable/disable:
 
 ## Behind the curtains
 
-### AVR ATmega328 and Atmega32u4
+### AVR ATmega168/328 and Atmega32u4
 
 The timer 1 is used with prescaler 1. With the arduino nano running at 16 MHz, timer overflow interrupts are generated every ~4 ms. This timer overflow interrupt is used for adjusting the speed. 
 

--- a/examples/Issue150/Issue150.ino
+++ b/examples/Issue150/Issue150.ino
@@ -4,7 +4,8 @@
 #include <avr/sleep.h>
 #endif
 
-#if defined(__AVR_ATmega328P__)
+#if (defined(__AVR_ATmega168__) || defined(__AVR_ATmega168P__) || \
+     defined(__AVR_ATmega328__) || defined(__AVR_ATmega328P__))
 #include "AVRStepperPins.h"
 #define dirPinStepperAVR 5
 #define stepPinStepperAVR stepPinStepper1A
@@ -23,7 +24,8 @@ void setup() {
   engine.init();
 
   // pins are set to outputs here automatically
-#if defined(__AVR_ATmega328P__)
+#if (defined(__AVR_ATmega168__) || defined(__AVR_ATmega168P__) || \
+     defined(__AVR_ATmega328__) || defined(__AVR_ATmega328P__))
   stepper = engine.stepperConnectToPin(stepPinStepperAVR);
   stepper->setDirectionPin(dirPinStepperAVR);
   stepper->setEnablePin(enablePinStepperAVR, true);

--- a/examples/Issue151/Issue151.ino
+++ b/examples/Issue151/Issue151.ino
@@ -4,7 +4,8 @@
 #include <avr/sleep.h>
 #endif
 
-#if defined(__AVR_ATmega328P__)
+#if (defined(__AVR_ATmega168__) || defined(__AVR_ATmega168P__) || \
+     defined(__AVR_ATmega328__) || defined(__AVR_ATmega328P__))
 #include "AVRStepperPins.h"
 #define dirPinStepperAVR 5
 #define stepPinStepperAVR stepPinStepper1A
@@ -23,7 +24,8 @@ void setup() {
   engine.init();
 
   // pins are set to outputs here automatically
-#if defined(__AVR_ATmega328P__)
+#if (defined(__AVR_ATmega168__) || defined(__AVR_ATmega168P__) || \
+     defined(__AVR_ATmega328__) || defined(__AVR_ATmega328P__))
   stepper = engine.stepperConnectToPin(stepPinStepperAVR);
   stepper->setDirectionPin(dirPinStepperAVR);
   stepper->setEnablePin(enablePinStepperAVR, true);

--- a/examples/Issue152/Issue152.ino
+++ b/examples/Issue152/Issue152.ino
@@ -4,7 +4,8 @@
 #include <avr/sleep.h>
 #endif
 
-#if defined(__AVR_ATmega328P__)
+#if (defined(__AVR_ATmega168__) || defined(__AVR_ATmega168P__) || \
+     defined(__AVR_ATmega328__) || defined(__AVR_ATmega328P__))
 #include "AVRStepperPins.h"
 #define dirPinStepperAVR 5
 #define stepPinStepperAVR stepPinStepper1A
@@ -23,7 +24,8 @@ void setup() {
   engine.init();
 
   // pins are set to outputs here automatically
-#if defined(__AVR_ATmega328P__)
+#if (defined(__AVR_ATmega168__) || defined(__AVR_ATmega168P__) || \
+     defined(__AVR_ATmega328__) || defined(__AVR_ATmega328P__))
   stepper = engine.stepperConnectToPin(stepPinStepperAVR);
   stepper->setDirectionPin(dirPinStepperAVR);
   stepper->setEnablePin(enablePinStepperAVR, true);

--- a/examples/Issue172/Issue172.ino
+++ b/examples/Issue172/Issue172.ino
@@ -4,7 +4,8 @@
 #include <avr/sleep.h>
 #endif
 
-#if defined(__AVR_ATmega328P__)
+#if (defined(__AVR_ATmega168__) || defined(__AVR_ATmega168P__) || \
+     defined(__AVR_ATmega328__) || defined(__AVR_ATmega328P__))
 #include "AVRStepperPins.h"
 #define dirPinStepperAVR 5
 #define stepPinStepperAVR stepPinStepper1A
@@ -23,7 +24,8 @@ void setup() {
   engine.init();
 
   // pins are set to outputs here automatically
-#if defined(__AVR_ATmega328P__)
+#if (defined(__AVR_ATmega168__) || defined(__AVR_ATmega168P__) || \
+     defined(__AVR_ATmega328__) || defined(__AVR_ATmega328P__))
   stepper = engine.stepperConnectToPin(stepPinStepperAVR);
   stepper->setDirectionPin(dirPinStepperAVR);
   stepper->setEnablePin(enablePinStepperAVR, true);

--- a/examples/Issue173/Issue173.ino
+++ b/examples/Issue173/Issue173.ino
@@ -4,7 +4,8 @@
 #include <avr/sleep.h>
 #endif
 
-#if defined(__AVR_ATmega328P__)
+#if (defined(__AVR_ATmega168__) || defined(__AVR_ATmega168P__) || \
+     defined(__AVR_ATmega328__) || defined(__AVR_ATmega328P__))
 #include "AVRStepperPins.h"
 #define dirPinStepperAVR 5
 #define stepPinStepperAVR stepPinStepper1A
@@ -24,7 +25,8 @@ void setup() {
   engine.init();
 
   // pins are set to outputs here automatically
-#if defined(__AVR_ATmega328P__)
+#if (defined(__AVR_ATmega168__) || defined(__AVR_ATmega168P__) || \
+     defined(__AVR_ATmega328__) || defined(__AVR_ATmega328P__))
   stepper = engine.stepperConnectToPin(stepPinStepperAVR);
   stepper->setDirectionPin(dirPinStepperAVR);
   stepper->setEnablePin(enablePinStepperAVR, true);

--- a/examples/StepperDemo/StepperDemo.ino
+++ b/examples/StepperDemo/StepperDemo.ino
@@ -24,7 +24,8 @@ struct stepper_config_s {
 };
 
 #if defined(ARDUINO_ARCH_AVR)
-#if defined(__AVR_ATmega328P__)
+#if (defined(__AVR_ATmega168__) || defined(__AVR_ATmega168P__) || \
+     defined(__AVR_ATmega328__) || defined(__AVR_ATmega328P__))
 // Example hardware configuration for Arduino Nano
 // Please adapt to your configuration
 const uint8_t led_pin = 13;  // turn off with PIN_UNDEFINED

--- a/extras/ci/platformio.ini
+++ b/extras/ci/platformio.ini
@@ -70,6 +70,13 @@ build_flags = -Werror -Wall -Wno-deprecated-declarations -Wno-error=incompatible
 board_build.f_cpu = 240000000L
 lib_extra_dirs = ../../..
 
+[env:nanoatmega168]
+platform    = atmelavr
+board       = nanoatmega168
+framework   = arduino
+build_flags = -Werror -Wall -Wno-deprecated-declarations
+lib_extra_dirs = ../../..
+
 [env:nanoatmega328]
 platform    = atmelavr
 board       = nanoatmega328

--- a/extras/doc/FastAccelStepper_API.md
+++ b/extras/doc/FastAccelStepper_API.md
@@ -2,7 +2,7 @@
 
 FastAccelStepper is a high speed alternative for the
 [AccelStepper library](http:www.airspayce.com/mikem/arduino/AccelStepper/).
-Supported are avr (ATmega 328, ATmega2560), esp32 and atmelsam due.
+Supported are avr (ATmega 168/328/P, ATmega2560), esp32 and atmelsam due.
 
 Here is a basic example to run a stepper from position 0 to 1000 and back
 again to 0.
@@ -79,14 +79,14 @@ This call allows to select the respective driver
 ```
 Comments to valid pins:
 
-| Device     | Comment                                                                                           |
-|:-----------|:--------------------------------------------------------------------------------------------------|
-| ESP32      | Every output capable GPIO can be used                                                             |
-| ESP32S2    | Every output capable GPIO can be used                                                             |
-| Atmega328p | Only the pins connected to OC1A and OC1B are allowed                                              |
-| Atmega2560 | Only the pins connected to OC4A, OC4B and OC4C are allowed.                                       |
-| Atmega32u4 | Only the pins connected to OC1A, OC1B and OC1C are allowed                                        |
-| Atmel SAM  | This can be one of each group of pins: 34/67/74/35, 17/36/72/37/42, 40/64/69/41, 9, 8/44, 7/45, 6 |
+| Device          | Comment                                                                                           |
+|:----------------|:--------------------------------------------------------------------------------------------------|
+| ESP32           | Every output capable GPIO can be used                                                             |
+| ESP32S2         | Every output capable GPIO can be used                                                             |
+| Atmega168/328/p | Only the pins connected to OC1A and OC1B are allowed                                              |
+| Atmega2560      | Only the pins connected to OC4A, OC4B and OC4C are allowed.                                       |
+| Atmega32u4      | Only the pins connected to OC1A, OC1B and OC1C are allowed                                        |
+| Atmel SAM       | This can be one of each group of pins: 34/67/74/35, 17/36/72/37/42, 40/64/69/41, 9, 8/44, 7/45, 6 |
 ## External Pins
 
 If the direction/enable pins are e.g. connected via external HW (shift

--- a/extras/scripts/build-platformio.sh
+++ b/extras/scripts/build-platformio.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-TARGETS=${1:-nanoatmega328 atmega2560 esp32 esp32s2 esp32c3 atmelsam atmega32u4}
+TARGETS=${1:-nanoatmega168 nanoatmega328 atmega2560 esp32 esp32s2 esp32c3 atmelsam atmega32u4}
 echo "execute for ${TARGETS}"
 
 if [ "$GITHUB_WORKSPACE" != "" ]
@@ -33,6 +33,10 @@ for i in pio_dirs/*
 do
 	for p in ${TARGETS}
 	do
+		if [ "$p" = "nanoatmega168" ] && [ "$i" = "pio_dirs/StepperDemo" ]; then
+		  echo $p: Skipping $i for $p due to space constraints
+		  continue
+		fi
 		echo $p: $i
 		(cd $i;pio run -s -e $p)
 	done

--- a/extras/tests/simavr_based/Makefile.test
+++ b/extras/tests/simavr_based/Makefile.test
@@ -7,6 +7,9 @@ SRC=$(wildcard ../../../src/*) $(wildcard src/*)
 
 # platformio should contain only one env section.
 # This section states the dut name
+#		atmega168
+#		atmega168p
+#		atmega328
 #		atmega328p
 #		atmega2560_timer1
 #		atmega2560_timer3
@@ -44,6 +47,21 @@ TRACES+=-at StepA=trace@0x10b/0x08 #OC5A PL3 46 ATMega2560
 TRACES+=-at StepB=trace@0x10b/0x10 #OC5B PL4 45 ATMega2560
 TRACES+=-at StepC=trace@0x10b/0x20 #OC5C PL5 44 ATMega2560
 
+else ifeq ($(DUT),atmega168)
+DEVICE=atmega168
+TRACES+=-at StepA=trace@0x25/0x02  #OC1A PB1 9  ATMega168
+TRACES+=-at StepB=trace@0x25/0x04  #OC1B PB2 10 ATMega168
+
+else ifeq ($(DUT),atmega168p)
+DEVICE=atmega168p
+TRACES+=-at StepA=trace@0x25/0x02  #OC1A PB1 9  ATMega168p
+TRACES+=-at StepB=trace@0x25/0x04  #OC1B PB2 10 ATMega168p
+
+else ifeq ($(DUT),atmega328)
+DEVICE=atmega328
+TRACES+=-at StepA=trace@0x25/0x02  #OC1A PB1 9  ATMega328
+TRACES+=-at StepB=trace@0x25/0x04  #OC1B PB2 10 ATMega328
+
 else ifeq ($(DUT),atmega328p)
 DEVICE=atmega328p
 TRACES+=-at StepA=trace@0x25/0x02  #OC1A PB1 9  ATMega328p
@@ -65,7 +83,7 @@ TRACES+=-at EnableA=trace@0x2b/0x04  # Pin 19 PD2
 TRACES+=-at EnableB=trace@0x2b/0x08  # Pin 18 PD3
 TRACES+=-at EnableC=trace@0x10b/0x40 # Pin 43 PL6
 
-else ifeq ($(DEVICE),atmega328p)
+else ifeq ($(DEVICE),$(filter $(DEVICE),atmega168 atmega168p atmega328 atmega328p))
 TRACES+=-at DirA=trace@0x2b/0x20     # Pin 5  PD5
 TRACES+=-at DirB=trace@0x2b/0x80     # Pin 7  PD7
 TRACES+=-at EnableA=trace@0x2b/0x40  # Pin 6  PD6

--- a/extras/tests/simavr_based/Raw/platformio.ini
+++ b/extras/tests/simavr_based/Raw/platformio.ini
@@ -12,6 +12,7 @@
 
 # There should be only one env section for the DUT under test.
 # One of
+#	atmega168p
 #	atmega328p
 #   atmega2560_timer1
 #   atmega2560_timer3
@@ -28,4 +29,3 @@ board       = nanoatmega328
 framework   = arduino
 build_flags = -Werror -Wall ${common.build_flags}
 lib_extra_dirs = ../../../../..
-

--- a/extras/tests/simavr_based/off_test_timing/platformio.ini
+++ b/extras/tests/simavr_based/off_test_timing/platformio.ini
@@ -12,6 +12,7 @@
 
 # There should be only one env section for the DUT under test.
 # One of
+#	atmega168p
 #	atmega328p
 #   atmega2560_timer1
 #   atmega2560_timer3

--- a/extras/tests/simavr_based/test_externalCall/Makefile
+++ b/extras/tests/simavr_based/test_externalCall/Makefile
@@ -7,6 +7,9 @@ SRC=$(wildcard ../../../src/*) $(wildcard src/*)
 
 # platformio should contain only one env section.
 # This section states the dut name
+#		atmega168
+#		atmega168p
+#		atmega328
 #		atmega328p
 #		atmega2560_timer1
 #		atmega2560_timer3
@@ -44,6 +47,21 @@ TRACES+=-at StepA=trace@0x10b/0x08 #OC5A PL3 46 ATMega2560
 TRACES+=-at StepB=trace@0x10b/0x10 #OC5B PL4 45 ATMega2560
 TRACES+=-at StepC=trace@0x10b/0x20 #OC5C PL5 44 ATMega2560
 
+else ifeq ($(DUT),atmega168)
+DEVICE=atmega168
+TRACES+=-at StepA=trace@0x25/0x02  #OC1A PB1 9  ATMega168
+TRACES+=-at StepB=trace@0x25/0x04  #OC1B PB2 10 ATMega168
+
+else ifeq ($(DUT),atmega168p)
+DEVICE=atmega168p
+TRACES+=-at StepA=trace@0x25/0x02  #OC1A PB1 9  ATMega168p
+TRACES+=-at StepB=trace@0x25/0x04  #OC1B PB2 10 ATMega168p
+
+else ifeq ($(DUT),atmega328)
+DEVICE=atmega328
+TRACES+=-at StepA=trace@0x25/0x02  #OC1A PB1 9  ATMega328
+TRACES+=-at StepB=trace@0x25/0x04  #OC1B PB2 10 ATMega328
+
 else ifeq ($(DUT),atmega328p)
 DEVICE=atmega328p
 TRACES+=-at StepA=trace@0x25/0x02  #OC1A PB1 9  ATMega328p
@@ -65,7 +83,7 @@ TRACES+=-at EnableA=trace@0x2b/0x04  # Pin 19 PD2
 TRACES+=-at EnableB=trace@0x2b/0x08  # Pin 18 PD3
 TRACES+=-at EnableC=trace@0x10b/0x40 # Pin 43 PL6
 
-else ifeq ($(DEVICE),atmega328p)
+else ifeq ($(DEVICE),$(filter $(DEVICE),atmega168 atmega168p atmega328 atmega328p))
 TRACES+=-at DirA=trace@0x2b/0x20     # Pin 5  PD5
 TRACES+=-at DirB=trace@0x2b/0x80     # Pin 7  PD7
 TRACES+=-at EnableA=trace@0x2b/0x40  # Pin 6  PD6

--- a/extras/tests/simavr_based/test_externalCall/platformio.ini
+++ b/extras/tests/simavr_based/test_externalCall/platformio.ini
@@ -12,6 +12,7 @@
 
 # There should be only one env section for the DUT under test.
 # One of
+#	atmega168p
 #	atmega328p
 #   atmega2560_timer1
 #   atmega2560_timer3
@@ -28,4 +29,3 @@ board       = nanoatmega328
 framework   = arduino
 build_flags = -Werror -Wall ${common.build_flags}
 lib_extra_dirs = ../../../../..
-

--- a/extras/tests/simavr_based/test_issue150/Makefile
+++ b/extras/tests/simavr_based/test_issue150/Makefile
@@ -7,6 +7,9 @@ SRC=$(wildcard ../../../src/*) $(wildcard src/*)
 
 # platformio should contain only one env section.
 # This section states the dut name
+#		atmega168
+#		atmega168p
+#		atmega328
 #		atmega328p
 #		atmega2560_timer1
 #		atmega2560_timer3
@@ -44,6 +47,21 @@ TRACES+=-at StepA=trace@0x10b/0x08 #OC5A PL3 46 ATMega2560
 TRACES+=-at StepB=trace@0x10b/0x10 #OC5B PL4 45 ATMega2560
 TRACES+=-at StepC=trace@0x10b/0x20 #OC5C PL5 44 ATMega2560
 
+else ifeq ($(DUT),atmega168)
+DEVICE=atmega168
+TRACES+=-at StepA=trace@0x25/0x02  #OC1A PB1 9  atmega168
+TRACES+=-at StepB=trace@0x25/0x04  #OC1B PB2 10 atmega168
+
+else ifeq ($(DUT),atmega168p)
+DEVICE=atmega168p
+TRACES+=-at StepA=trace@0x25/0x02  #OC1A PB1 9  atmega168p
+TRACES+=-at StepB=trace@0x25/0x04  #OC1B PB2 10 atmega168p
+
+else ifeq ($(DUT),atmega328)
+DEVICE=atmega328
+TRACES+=-at StepA=trace@0x25/0x02  #OC1A PB1 9  ATMega328
+TRACES+=-at StepB=trace@0x25/0x04  #OC1B PB2 10 ATMega328
+
 else ifeq ($(DUT),atmega328p)
 DEVICE=atmega328p
 TRACES+=-at StepA=trace@0x25/0x02  #OC1A PB1 9  ATMega328p
@@ -65,7 +83,7 @@ TRACES+=-at EnableA=trace@0x2b/0x04  # Pin 19 PD2
 TRACES+=-at EnableB=trace@0x2b/0x08  # Pin 18 PD3
 TRACES+=-at EnableC=trace@0x10b/0x40 # Pin 43 PL6
 
-else ifeq ($(DEVICE),atmega328p)
+else ifeq ($(DEVICE),$(filter $(DEVICE),atmega168 atmega168p atmega328 atmega328p))
 TRACES+=-at DirA=trace@0x2b/0x20     # Pin 5  PD5
 TRACES+=-at DirB=trace@0x2b/0x80     # Pin 7  PD7
 TRACES+=-at EnableA=trace@0x2b/0x40  # Pin 6  PD6

--- a/extras/tests/simavr_based/test_issue150/platformio.ini
+++ b/extras/tests/simavr_based/test_issue150/platformio.ini
@@ -12,6 +12,7 @@
 
 # There should be only one env section for the DUT under test.
 # One of
+#	atmega168p
 #	atmega328p
 #   atmega2560_timer1
 #   atmega2560_timer3
@@ -28,4 +29,3 @@ board       = nanoatmega328
 framework   = arduino
 build_flags = -Werror -Wall ${common.build_flags}
 lib_extra_dirs = ../../../../..
-

--- a/extras/tests/simavr_based/test_issue151/Makefile
+++ b/extras/tests/simavr_based/test_issue151/Makefile
@@ -7,6 +7,9 @@ SRC=$(wildcard ../../../src/*) $(wildcard src/*)
 
 # platformio should contain only one env section.
 # This section states the dut name
+#		atmega168
+#		atmega168p
+#		atmega328
 #		atmega328p
 #		atmega2560_timer1
 #		atmega2560_timer3
@@ -44,6 +47,21 @@ TRACES+=-at StepA=trace@0x10b/0x08 #OC5A PL3 46 ATMega2560
 TRACES+=-at StepB=trace@0x10b/0x10 #OC5B PL4 45 ATMega2560
 TRACES+=-at StepC=trace@0x10b/0x20 #OC5C PL5 44 ATMega2560
 
+else ifeq ($(DUT),atmega168)
+DEVICE=atmega168
+TRACES+=-at StepA=trace@0x25/0x02  #OC1A PB1 9  atmega168
+TRACES+=-at StepB=trace@0x25/0x04  #OC1B PB2 10 atmega168
+
+else ifeq ($(DUT),atmega168p)
+DEVICE=atmega168p
+TRACES+=-at StepA=trace@0x25/0x02  #OC1A PB1 9  atmega168p
+TRACES+=-at StepB=trace@0x25/0x04  #OC1B PB2 10 atmega168p
+
+else ifeq ($(DUT),atmega328)
+DEVICE=atmega328
+TRACES+=-at StepA=trace@0x25/0x02  #OC1A PB1 9  ATMega328
+TRACES+=-at StepB=trace@0x25/0x04  #OC1B PB2 10 ATMega328
+
 else ifeq ($(DUT),atmega328p)
 DEVICE=atmega328p
 TRACES+=-at StepA=trace@0x25/0x02  #OC1A PB1 9  ATMega328p
@@ -65,7 +83,7 @@ TRACES+=-at EnableA=trace@0x2b/0x04  # Pin 19 PD2
 TRACES+=-at EnableB=trace@0x2b/0x08  # Pin 18 PD3
 TRACES+=-at EnableC=trace@0x10b/0x40 # Pin 43 PL6
 
-else ifeq ($(DEVICE),atmega328p)
+else ifeq ($(DEVICE),$(filter $(DEVICE),atmega168 atmega168p atmega328 atmega328p))
 TRACES+=-at DirA=trace@0x2b/0x20     # Pin 5  PD5
 TRACES+=-at DirB=trace@0x2b/0x80     # Pin 7  PD7
 TRACES+=-at EnableA=trace@0x2b/0x40  # Pin 6  PD6

--- a/extras/tests/simavr_based/test_issue151/platformio.ini
+++ b/extras/tests/simavr_based/test_issue151/platformio.ini
@@ -12,6 +12,7 @@
 
 # There should be only one env section for the DUT under test.
 # One of
+#	atmega168p
 #	atmega328p
 #   atmega2560_timer1
 #   atmega2560_timer3
@@ -28,4 +29,3 @@ board       = nanoatmega328
 framework   = arduino
 build_flags = -Werror -Wall ${common.build_flags}
 lib_extra_dirs = ../../../../..
-

--- a/extras/tests/simavr_based/test_issue152/Makefile
+++ b/extras/tests/simavr_based/test_issue152/Makefile
@@ -7,6 +7,9 @@ SRC=$(wildcard ../../../src/*) $(wildcard src/*)
 
 # platformio should contain only one env section.
 # This section states the dut name
+#		atmega168
+#		atmega168p
+#		atmega328
 #		atmega328p
 #		atmega2560_timer1
 #		atmega2560_timer3
@@ -44,6 +47,21 @@ TRACES+=-at StepA=trace@0x10b/0x08 #OC5A PL3 46 ATMega2560
 TRACES+=-at StepB=trace@0x10b/0x10 #OC5B PL4 45 ATMega2560
 TRACES+=-at StepC=trace@0x10b/0x20 #OC5C PL5 44 ATMega2560
 
+else ifeq ($(DUT),atmega168)
+DEVICE=atmega168
+TRACES+=-at StepA=trace@0x25/0x02  #OC1A PB1 9  atmega168
+TRACES+=-at StepB=trace@0x25/0x04  #OC1B PB2 10 atmega168
+
+else ifeq ($(DUT),atmega168p)
+DEVICE=atmega168p
+TRACES+=-at StepA=trace@0x25/0x02  #OC1A PB1 9  atmega168p
+TRACES+=-at StepB=trace@0x25/0x04  #OC1B PB2 10 atmega168p
+
+else ifeq ($(DUT),atmega328)
+DEVICE=atmega328
+TRACES+=-at StepA=trace@0x25/0x02  #OC1A PB1 9  ATMega328
+TRACES+=-at StepB=trace@0x25/0x04  #OC1B PB2 10 ATMega328
+
 else ifeq ($(DUT),atmega328p)
 DEVICE=atmega328p
 TRACES+=-at StepA=trace@0x25/0x02  #OC1A PB1 9  ATMega328p
@@ -65,7 +83,7 @@ TRACES+=-at EnableA=trace@0x2b/0x04  # Pin 19 PD2
 TRACES+=-at EnableB=trace@0x2b/0x08  # Pin 18 PD3
 TRACES+=-at EnableC=trace@0x10b/0x40 # Pin 43 PL6
 
-else ifeq ($(DEVICE),atmega328p)
+else ifeq ($(DEVICE),$(filter $(DEVICE),atmega168 atmega168p atmega328 atmega328p))
 TRACES+=-at DirA=trace@0x2b/0x20     # Pin 5  PD5
 TRACES+=-at DirB=trace@0x2b/0x80     # Pin 7  PD7
 TRACES+=-at EnableA=trace@0x2b/0x40  # Pin 6  PD6

--- a/extras/tests/simavr_based/test_issue152/platformio.ini
+++ b/extras/tests/simavr_based/test_issue152/platformio.ini
@@ -12,6 +12,7 @@
 
 # There should be only one env section for the DUT under test.
 # One of
+#	atmega168p
 #	atmega328p
 #   atmega2560_timer1
 #   atmega2560_timer3
@@ -28,4 +29,3 @@ board       = nanoatmega328
 framework   = arduino
 build_flags = -Werror -Wall ${common.build_flags}
 lib_extra_dirs = ../../../../..
-

--- a/extras/tests/simavr_based/test_issue172/Makefile
+++ b/extras/tests/simavr_based/test_issue172/Makefile
@@ -7,6 +7,9 @@ SRC=$(wildcard ../../../src/*) $(wildcard src/*)
 
 # platformio should contain only one env section.
 # This section states the dut name
+#		atmega168
+#		atmega168p
+#		atmega328
 #		atmega328p
 #		atmega2560_timer1
 #		atmega2560_timer3
@@ -44,6 +47,21 @@ TRACES+=-at StepA=trace@0x10b/0x08 #OC5A PL3 46 ATMega2560
 TRACES+=-at StepB=trace@0x10b/0x10 #OC5B PL4 45 ATMega2560
 TRACES+=-at StepC=trace@0x10b/0x20 #OC5C PL5 44 ATMega2560
 
+else ifeq ($(DUT),atmega168)
+DEVICE=atmega168
+TRACES+=-at StepA=trace@0x25/0x02  #OC1A PB1 9  atmega168
+TRACES+=-at StepB=trace@0x25/0x04  #OC1B PB2 10 atmega168
+
+else ifeq ($(DUT),atmega168p)
+DEVICE=atmega168p
+TRACES+=-at StepA=trace@0x25/0x02  #OC1A PB1 9  atmega168p
+TRACES+=-at StepB=trace@0x25/0x04  #OC1B PB2 10 atmega168p
+
+else ifeq ($(DUT),atmega328)
+DEVICE=atmega328
+TRACES+=-at StepA=trace@0x25/0x02  #OC1A PB1 9  ATMega328
+TRACES+=-at StepB=trace@0x25/0x04  #OC1B PB2 10 ATMega328
+
 else ifeq ($(DUT),atmega328p)
 DEVICE=atmega328p
 TRACES+=-at StepA=trace@0x25/0x02  #OC1A PB1 9  ATMega328p
@@ -65,7 +83,7 @@ TRACES+=-at EnableA=trace@0x2b/0x04  # Pin 19 PD2
 TRACES+=-at EnableB=trace@0x2b/0x08  # Pin 18 PD3
 TRACES+=-at EnableC=trace@0x10b/0x40 # Pin 43 PL6
 
-else ifeq ($(DEVICE),atmega328p)
+else ifeq ($(DEVICE),$(filter $(DEVICE),atmega168 atmega168p atmega328 atmega328p))
 TRACES+=-at DirA=trace@0x2b/0x20     # Pin 5  PD5
 TRACES+=-at DirB=trace@0x2b/0x80     # Pin 7  PD7
 TRACES+=-at EnableA=trace@0x2b/0x40  # Pin 6  PD6

--- a/extras/tests/simavr_based/test_issue172/platformio.ini
+++ b/extras/tests/simavr_based/test_issue172/platformio.ini
@@ -12,6 +12,7 @@
 
 # There should be only one env section for the DUT under test.
 # One of
+#	atmega168p
 #	atmega328p
 #   atmega2560_timer1
 #   atmega2560_timer3
@@ -28,4 +29,3 @@ board       = nanoatmega328
 framework   = arduino
 build_flags = -Werror -Wall ${common.build_flags}
 lib_extra_dirs = ../../../../..
-

--- a/extras/tests/simavr_based/test_issue173/Makefile
+++ b/extras/tests/simavr_based/test_issue173/Makefile
@@ -7,6 +7,9 @@ SRC=$(wildcard ../../../src/*) $(wildcard src/*)
 
 # platformio should contain only one env section.
 # This section states the dut name
+#		atmega168
+#		atmega168p
+#		atmega328
 #		atmega328p
 #		atmega2560_timer1
 #		atmega2560_timer3
@@ -44,6 +47,21 @@ TRACES+=-at StepA=trace@0x10b/0x08 #OC5A PL3 46 ATMega2560
 TRACES+=-at StepB=trace@0x10b/0x10 #OC5B PL4 45 ATMega2560
 TRACES+=-at StepC=trace@0x10b/0x20 #OC5C PL5 44 ATMega2560
 
+else ifeq ($(DUT),atmega168)
+DEVICE=atmega168
+TRACES+=-at StepA=trace@0x25/0x02  #OC1A PB1 9  atmega168
+TRACES+=-at StepB=trace@0x25/0x04  #OC1B PB2 10 atmega168
+
+else ifeq ($(DUT),atmega168p)
+DEVICE=atmega168p
+TRACES+=-at StepA=trace@0x25/0x02  #OC1A PB1 9  atmega168p
+TRACES+=-at StepB=trace@0x25/0x04  #OC1B PB2 10 atmega168p
+
+else ifeq ($(DUT),atmega328)
+DEVICE=atmega328
+TRACES+=-at StepA=trace@0x25/0x02  #OC1A PB1 9  ATMega328
+TRACES+=-at StepB=trace@0x25/0x04  #OC1B PB2 10 ATMega328
+
 else ifeq ($(DUT),atmega328p)
 DEVICE=atmega328p
 TRACES+=-at StepA=trace@0x25/0x02  #OC1A PB1 9  ATMega328p
@@ -65,7 +83,7 @@ TRACES+=-at EnableA=trace@0x2b/0x04  # Pin 19 PD2
 TRACES+=-at EnableB=trace@0x2b/0x08  # Pin 18 PD3
 TRACES+=-at EnableC=trace@0x10b/0x40 # Pin 43 PL6
 
-else ifeq ($(DEVICE),atmega328p)
+else ifeq ($(DEVICE),$(filter $(DEVICE),atmega168 atmega168p atmega328 atmega328p))
 TRACES+=-at DirA=trace@0x2b/0x20     # Pin 5  PD5
 TRACES+=-at DirB=trace@0x2b/0x80     # Pin 7  PD7
 TRACES+=-at EnableA=trace@0x2b/0x40  # Pin 6  PD6

--- a/extras/tests/simavr_based/test_issue173/platformio.ini
+++ b/extras/tests/simavr_based/test_issue173/platformio.ini
@@ -12,6 +12,7 @@
 
 # There should be only one env section for the DUT under test.
 # One of
+#	atmega168p
 #	atmega328p
 #   atmega2560_timer1
 #   atmega2560_timer3
@@ -28,4 +29,3 @@ board       = nanoatmega328
 framework   = arduino
 build_flags = -Werror -Wall ${common.build_flags}
 lib_extra_dirs = ../../../../..
-

--- a/extras/tests/simavr_based/test_pmf/Makefile
+++ b/extras/tests/simavr_based/test_pmf/Makefile
@@ -7,6 +7,9 @@ SRC=$(wildcard ../../../src/*) $(wildcard src/*)
 
 # platformio should contain only one env section.
 # This section states the dut name
+#		atmega168
+#		atmega168p
+#		atmega328
 #		atmega328p
 #		atmega2560_timer1
 #		atmega2560_timer3
@@ -44,6 +47,21 @@ TRACES+=-at StepA=trace@0x10b/0x08 #OC5A PL3 46 ATMega2560
 TRACES+=-at StepB=trace@0x10b/0x10 #OC5B PL4 45 ATMega2560
 TRACES+=-at StepC=trace@0x10b/0x20 #OC5C PL5 44 ATMega2560
 
+else ifeq ($(DUT),atmega168)
+DEVICE=atmega168
+TRACES+=-at StepA=trace@0x25/0x02  #OC1A PB1 9  atmega168
+TRACES+=-at StepB=trace@0x25/0x04  #OC1B PB2 10 atmega168
+
+else ifeq ($(DUT),atmega168p)
+DEVICE=atmega168p
+TRACES+=-at StepA=trace@0x25/0x02  #OC1A PB1 9  atmega168p
+TRACES+=-at StepB=trace@0x25/0x04  #OC1B PB2 10 atmega168p
+
+else ifeq ($(DUT),atmega328)
+DEVICE=atmega328
+TRACES+=-at StepA=trace@0x25/0x02  #OC1A PB1 9  ATMega328
+TRACES+=-at StepB=trace@0x25/0x04  #OC1B PB2 10 ATMega328
+
 else ifeq ($(DUT),atmega328p)
 DEVICE=atmega328p
 TRACES+=-at StepA=trace@0x25/0x02  #OC1A PB1 9  ATMega328p
@@ -65,7 +83,7 @@ TRACES+=-at EnableA=trace@0x2b/0x04  # Pin 19 PD2
 TRACES+=-at EnableB=trace@0x2b/0x08  # Pin 18 PD3
 TRACES+=-at EnableC=trace@0x10b/0x40 # Pin 43 PL6
 
-else ifeq ($(DEVICE),atmega328p)
+else ifeq ($(DEVICE),$(filter $(DEVICE),atmega168 atmega168p atmega328 atmega328p))
 TRACES+=-at DirA=trace@0x2b/0x20     # Pin 5  PD5
 TRACES+=-at DirB=trace@0x2b/0x80     # Pin 7  PD7
 TRACES+=-at EnableA=trace@0x2b/0x40  # Pin 6  PD6

--- a/extras/tests/simavr_based/test_pmf/platformio.ini
+++ b/extras/tests/simavr_based/test_pmf/platformio.ini
@@ -12,6 +12,7 @@
 
 # There should be only one env section for the DUT under test.
 # One of
+#	atmega168p
 #	atmega328p
 #   atmega2560_timer1
 #   atmega2560_timer3
@@ -28,4 +29,3 @@ board       = nanoatmega328
 framework   = arduino
 build_flags = -Werror -Wall ${common.build_flags}
 lib_extra_dirs = ../../../../..
-

--- a/extras/tests/simavr_based/test_sd_01a_2560t1/platformio.ini
+++ b/extras/tests/simavr_based/test_sd_01a_2560t1/platformio.ini
@@ -12,6 +12,7 @@
 
 # There should be only one env section for the DUT under test.
 # One of
+#	atmega168p
 #	atmega328p
 #   atmega2560_timer1
 #   atmega2560_timer3

--- a/extras/tests/simavr_based/test_sd_01a_2560t3/platformio.ini
+++ b/extras/tests/simavr_based/test_sd_01a_2560t3/platformio.ini
@@ -12,6 +12,7 @@
 
 # There should be only one env section for the DUT under test.
 # One of
+#	atmega168p
 #	atmega328p
 #   atmega2560_timer1
 #   atmega2560_timer3

--- a/extras/tests/simavr_based/test_sd_01a_2560t4/platformio.ini
+++ b/extras/tests/simavr_based/test_sd_01a_2560t4/platformio.ini
@@ -12,6 +12,7 @@
 
 # There should be only one env section for the DUT under test.
 # One of
+#	atmega168p
 #	atmega328p
 #   atmega2560_timer1
 #   atmega2560_timer3

--- a/extras/tests/simavr_based/test_sd_01a_2560t5/platformio.ini
+++ b/extras/tests/simavr_based/test_sd_01a_2560t5/platformio.ini
@@ -12,6 +12,7 @@
 
 # There should be only one env section for the DUT under test.
 # One of
+#	atmega168p
 #	atmega328p
 #   atmega2560_timer1
 #   atmega2560_timer3

--- a/extras/tests/simavr_based/test_sd_01a_328p/platformio.ini
+++ b/extras/tests/simavr_based/test_sd_01a_328p/platformio.ini
@@ -12,6 +12,7 @@
 
 # There should be only one env section for the DUT under test.
 # One of
+#	atmega168p
 #	atmega328p
 #   atmega2560_timer1
 #   atmega2560_timer3
@@ -28,4 +29,3 @@ board       = nanoatmega328
 framework   = arduino
 build_flags = -Werror -Wall ${common.build_flags}
 lib_extra_dirs = ../../../../..
-

--- a/extras/tests/simavr_based/test_sd_01a_leonardo/platformio.ini
+++ b/extras/tests/simavr_based/test_sd_01a_leonardo/platformio.ini
@@ -12,6 +12,7 @@
 
 # There should be only one env section for the DUT under test.
 # One of
+#	atmega168p
 #	atmega328p
 #   atmega2560_timer1
 #   atmega2560_timer3

--- a/extras/tests/simavr_based/test_sd_01b_2560t1/platformio.ini
+++ b/extras/tests/simavr_based/test_sd_01b_2560t1/platformio.ini
@@ -12,6 +12,7 @@
 
 # There should be only one env section for the DUT under test.
 # One of
+#	atmega168p
 #	atmega328p
 #   atmega2560_timer1
 #   atmega2560_timer3

--- a/extras/tests/simavr_based/test_sd_01b_2560t3/platformio.ini
+++ b/extras/tests/simavr_based/test_sd_01b_2560t3/platformio.ini
@@ -12,6 +12,7 @@
 
 # There should be only one env section for the DUT under test.
 # One of
+#	atmega168p
 #	atmega328p
 #   atmega2560_timer1
 #   atmega2560_timer3

--- a/extras/tests/simavr_based/test_sd_01b_2560t4/platformio.ini
+++ b/extras/tests/simavr_based/test_sd_01b_2560t4/platformio.ini
@@ -12,6 +12,7 @@
 
 # There should be only one env section for the DUT under test.
 # One of
+#	atmega168p
 #	atmega328p
 #   atmega2560_timer1
 #   atmega2560_timer3

--- a/extras/tests/simavr_based/test_sd_01b_2560t5/platformio.ini
+++ b/extras/tests/simavr_based/test_sd_01b_2560t5/platformio.ini
@@ -12,6 +12,7 @@
 
 # There should be only one env section for the DUT under test.
 # One of
+#	atmega168p
 #	atmega328p
 #   atmega2560_timer1
 #   atmega2560_timer3

--- a/extras/tests/simavr_based/test_sd_01b_328p/platformio.ini
+++ b/extras/tests/simavr_based/test_sd_01b_328p/platformio.ini
@@ -12,6 +12,7 @@
 
 # There should be only one env section for the DUT under test.
 # One of
+#	atmega168p
 #	atmega328p
 #   atmega2560_timer1
 #   atmega2560_timer3
@@ -28,4 +29,3 @@ board       = nanoatmega328
 framework   = arduino
 build_flags = -Werror -Wall ${common.build_flags}
 lib_extra_dirs = ../../../../..
-

--- a/extras/tests/simavr_based/test_sd_01c_2560t1/platformio.ini
+++ b/extras/tests/simavr_based/test_sd_01c_2560t1/platformio.ini
@@ -12,6 +12,7 @@
 
 # There should be only one env section for the DUT under test.
 # One of
+#	atmega168p
 #	atmega328p
 #   atmega2560_timer1
 #   atmega2560_timer3

--- a/extras/tests/simavr_based/test_sd_01c_2560t3/platformio.ini
+++ b/extras/tests/simavr_based/test_sd_01c_2560t3/platformio.ini
@@ -12,6 +12,7 @@
 
 # There should be only one env section for the DUT under test.
 # One of
+#	atmega168p
 #	atmega328p
 #   atmega2560_timer1
 #   atmega2560_timer3

--- a/extras/tests/simavr_based/test_sd_01c_2560t4/platformio.ini
+++ b/extras/tests/simavr_based/test_sd_01c_2560t4/platformio.ini
@@ -12,6 +12,7 @@
 
 # There should be only one env section for the DUT under test.
 # One of
+#	atmega168p
 #	atmega328p
 #   atmega2560_timer1
 #   atmega2560_timer3

--- a/extras/tests/simavr_based/test_sd_01c_2560t5/platformio.ini
+++ b/extras/tests/simavr_based/test_sd_01c_2560t5/platformio.ini
@@ -12,6 +12,7 @@
 
 # There should be only one env section for the DUT under test.
 # One of
+#	atmega168p
 #	atmega328p
 #   atmega2560_timer1
 #   atmega2560_timer3

--- a/extras/tests/simavr_based/test_sd_02_328p/platformio.ini
+++ b/extras/tests/simavr_based/test_sd_02_328p/platformio.ini
@@ -12,6 +12,7 @@
 
 # There should be only one env section for the DUT under test.
 # One of
+#	atmega168p
 #	atmega328p
 #   atmega2560_timer1
 #   atmega2560_timer3

--- a/extras/tests/simavr_based/test_sd_03_328p/platformio.ini
+++ b/extras/tests/simavr_based/test_sd_03_328p/platformio.ini
@@ -12,6 +12,7 @@
 
 # There should be only one env section for the DUT under test.
 # One of
+#	atmega168p
 #	atmega328p
 #   atmega2560_timer1
 #   atmega2560_timer3
@@ -28,4 +29,3 @@ board       = nanoatmega328
 framework   = arduino
 build_flags = -Werror -Wall ${common.build_flags}
 lib_extra_dirs = ../../../../..
-

--- a/extras/tests/simavr_based/test_sd_04_timing_2560/platformio.ini
+++ b/extras/tests/simavr_based/test_sd_04_timing_2560/platformio.ini
@@ -12,6 +12,7 @@
 
 # There should be only one env section for the DUT under test.
 # One of
+#	atmega168p
 #	atmega328p
 #   atmega2560_timer1
 #   atmega2560_timer3

--- a/extras/tests/simavr_based/test_sd_04_timing_328p/platformio.ini
+++ b/extras/tests/simavr_based/test_sd_04_timing_328p/platformio.ini
@@ -12,6 +12,7 @@
 
 # There should be only one env section for the DUT under test.
 # One of
+#	atmega168p
 #	atmega328p
 #   atmega2560_timer1
 #   atmega2560_timer3
@@ -28,4 +29,3 @@ board       = nanoatmega328
 framework   = arduino
 build_flags = -Werror -Wall ${common.build_flags}
 lib_extra_dirs = ../../../../..
-

--- a/extras/tests/simavr_based/test_sd_04_timing_328p_37k/platformio.ini
+++ b/extras/tests/simavr_based/test_sd_04_timing_328p_37k/platformio.ini
@@ -12,6 +12,7 @@
 
 # There should be only one env section for the DUT under test.
 # One of
+#	atmega168p
 #	atmega328p
 #   atmega2560_timer1
 #   atmega2560_timer3
@@ -28,4 +29,3 @@ board       = nanoatmega328
 framework   = arduino
 build_flags = -Werror -Wall ${common.build_flags}
 lib_extra_dirs = ../../../../..
-

--- a/extras/tests/simavr_based/test_sd_05_328p/platformio.ini
+++ b/extras/tests/simavr_based/test_sd_05_328p/platformio.ini
@@ -12,6 +12,7 @@
 
 # There should be only one env section for the DUT under test.
 # One of
+#	atmega168p
 #	atmega328p
 #   atmega2560_timer1
 #   atmega2560_timer3
@@ -28,4 +29,3 @@ board       = nanoatmega328
 framework   = arduino
 build_flags = -Werror -Wall ${common.build_flags}
 lib_extra_dirs = ../../../../..
-

--- a/extras/tests/simavr_based/test_sd_06_328p/platformio.ini
+++ b/extras/tests/simavr_based/test_sd_06_328p/platformio.ini
@@ -12,6 +12,7 @@
 
 # There should be only one env section for the DUT under test.
 # One of
+#	atmega168p
 #	atmega328p
 #   atmega2560_timer1
 #   atmega2560_timer3
@@ -28,4 +29,3 @@ board       = nanoatmega328
 framework   = arduino
 build_flags = -Werror -Wall ${common.build_flags}
 lib_extra_dirs = ../../../../..
-

--- a/extras/tests/simavr_based/test_sd_07_328p/platformio.ini
+++ b/extras/tests/simavr_based/test_sd_07_328p/platformio.ini
@@ -12,6 +12,7 @@
 
 # There should be only one env section for the DUT under test.
 # One of
+#	atmega168p
 #	atmega328p
 #   atmega2560_timer1
 #   atmega2560_timer3
@@ -28,4 +29,3 @@ board       = nanoatmega328
 framework   = arduino
 build_flags = -Werror -Wall ${common.build_flags}
 lib_extra_dirs = ../../../../..
-

--- a/extras/tests/simavr_based/test_sd_08_328p/platformio.ini
+++ b/extras/tests/simavr_based/test_sd_08_328p/platformio.ini
@@ -12,6 +12,7 @@
 
 # There should be only one env section for the DUT under test.
 # One of
+#	atmega168p
 #	atmega328p
 #   atmega2560_timer1
 #   atmega2560_timer3
@@ -28,4 +29,3 @@ board       = nanoatmega328
 framework   = arduino
 build_flags = -Werror -Wall ${common.build_flags}
 lib_extra_dirs = ../../../../..
-

--- a/extras/tests/simavr_based/test_sd_09_328p/platformio.ini
+++ b/extras/tests/simavr_based/test_sd_09_328p/platformio.ini
@@ -12,6 +12,7 @@
 
 # There should be only one env section for the DUT under test.
 # One of
+#	atmega168p
 #	atmega328p
 #   atmega2560_timer1
 #   atmega2560_timer3
@@ -28,4 +29,3 @@ board       = nanoatmega328
 framework   = arduino
 build_flags = -Werror -Wall ${common.build_flags}
 lib_extra_dirs = ../../../../..
-

--- a/extras/tests/simavr_based/test_sd_10_328p/platformio.ini
+++ b/extras/tests/simavr_based/test_sd_10_328p/platformio.ini
@@ -12,6 +12,7 @@
 
 # There should be only one env section for the DUT under test.
 # One of
+#	atmega168p
 #	atmega328p
 #   atmega2560_timer1
 #   atmega2560_timer3
@@ -28,4 +29,3 @@ board       = nanoatmega328
 framework   = arduino
 build_flags = -Werror -Wall ${common.build_flags}
 lib_extra_dirs = ../../../../..
-

--- a/extras/tests/simavr_based/test_sd_11_328p/platformio.ini
+++ b/extras/tests/simavr_based/test_sd_11_328p/platformio.ini
@@ -12,6 +12,7 @@
 
 # There should be only one env section for the DUT under test.
 # One of
+#	atmega168p
 #	atmega328p
 #   atmega2560_timer1
 #   atmega2560_timer3
@@ -28,4 +29,3 @@ board       = nanoatmega328
 framework   = arduino
 build_flags = -Werror -Wall ${common.build_flags}
 lib_extra_dirs = ../../../../..
-

--- a/extras/tests/simavr_based/test_sd_12_328p/platformio.ini
+++ b/extras/tests/simavr_based/test_sd_12_328p/platformio.ini
@@ -12,6 +12,7 @@
 
 # There should be only one env section for the DUT under test.
 # One of
+#	atmega168p
 #	atmega328p
 #   atmega2560_timer1
 #   atmega2560_timer3
@@ -28,4 +29,3 @@ board       = nanoatmega328
 framework   = arduino
 build_flags = -Werror -Wall ${common.build_flags}
 lib_extra_dirs = ../../../../..
-

--- a/extras/tests/simavr_based/test_sd_13_328p/platformio.ini
+++ b/extras/tests/simavr_based/test_sd_13_328p/platformio.ini
@@ -12,6 +12,7 @@
 
 # There should be only one env section for the DUT under test.
 # One of
+#	atmega168p
 #	atmega328p
 #   atmega2560_timer1
 #   atmega2560_timer3
@@ -28,4 +29,3 @@ board       = nanoatmega328
 framework   = arduino
 build_flags = -Werror -Wall ${common.build_flags}
 lib_extra_dirs = ../../../../..
-

--- a/extras/tests/simavr_based/test_sd_14_328p/platformio.ini
+++ b/extras/tests/simavr_based/test_sd_14_328p/platformio.ini
@@ -12,6 +12,7 @@
 
 # There should be only one env section for the DUT under test.
 # One of
+#	atmega168p
 #	atmega328p
 #   atmega2560_timer1
 #   atmega2560_timer3
@@ -28,4 +29,3 @@ board       = nanoatmega328
 framework   = arduino
 build_flags = -Werror -Wall ${common.build_flags}
 lib_extra_dirs = ../../../../..
-

--- a/extras/tests/simavr_based/test_sd_15_328p/platformio.ini
+++ b/extras/tests/simavr_based/test_sd_15_328p/platformio.ini
@@ -12,6 +12,7 @@
 
 # There should be only one env section for the DUT under test.
 # One of
+#	atmega168p
 #	atmega328p
 #   atmega2560_timer1
 #   atmega2560_timer3
@@ -37,4 +38,3 @@ board       = nanoatmega328
 framework   = arduino
 build_flags = -Werror -Wall ${common.build_flags}
 lib_extra_dirs = ../../../../..
-

--- a/extras/tests/simavr_based/test_sd_16_328p/platformio.ini
+++ b/extras/tests/simavr_based/test_sd_16_328p/platformio.ini
@@ -12,6 +12,7 @@
 
 # There should be only one env section for the DUT under test.
 # One of
+#	atmega168p
 #	atmega328p
 #   atmega2560_timer1
 #   atmega2560_timer3
@@ -31,4 +32,3 @@ board       = nanoatmega328
 framework   = arduino
 build_flags = -Werror -Wall ${common.build_flags}
 lib_extra_dirs = ../../../../..
-

--- a/extras/tests/simavr_based/test_sd_17_328p/platformio.ini
+++ b/extras/tests/simavr_based/test_sd_17_328p/platformio.ini
@@ -12,6 +12,7 @@
 
 # There should be only one env section for the DUT under test.
 # One of
+#	atmega168p
 #	atmega328p
 #   atmega2560_timer1
 #   atmega2560_timer3
@@ -31,4 +32,3 @@ board       = nanoatmega328
 framework   = arduino
 build_flags = -Werror -Wall ${common.build_flags}
 lib_extra_dirs = ../../../../..
-

--- a/extras/tests/simavr_based/test_sd_18_328p/platformio.ini
+++ b/extras/tests/simavr_based/test_sd_18_328p/platformio.ini
@@ -12,6 +12,7 @@
 
 # There should be only one env section for the DUT under test.
 # One of
+#	atmega168p
 #	atmega328p
 #   atmega2560_timer1
 #   atmega2560_timer3
@@ -32,4 +33,3 @@ board       = nanoatmega328
 framework   = arduino
 build_flags = -Werror -Wall ${common.build_flags}
 lib_extra_dirs = ../../../../..
-

--- a/extras/tests/simavr_based/test_sd_19_328p/platformio.ini
+++ b/extras/tests/simavr_based/test_sd_19_328p/platformio.ini
@@ -12,6 +12,7 @@
 
 # There should be only one env section for the DUT under test.
 # One of
+#	atmega168p
 #	atmega328p
 #   atmega2560_timer1
 #   atmega2560_timer3
@@ -32,4 +33,3 @@ board       = nanoatmega328
 framework   = arduino
 build_flags = -Werror -Wall ${common.build_flags}
 lib_extra_dirs = ../../../../..
-

--- a/extras/tests/simavr_based/test_seq_sd_01_328p/platformio.ini
+++ b/extras/tests/simavr_based/test_seq_sd_01_328p/platformio.ini
@@ -12,6 +12,7 @@
 
 # There should be only one env section for the DUT under test.
 # One of
+#	atmega168p
 #	atmega328p
 #   atmega2560_timer1
 #   atmega2560_timer3
@@ -28,4 +29,3 @@ board       = nanoatmega328
 framework   = arduino
 build_flags = -Werror -Wall ${common.build_flags}
 lib_extra_dirs = ../../../../..
-

--- a/extras/tests/simavr_based/test_seq_sd_06_328p/platformio.ini
+++ b/extras/tests/simavr_based/test_seq_sd_06_328p/platformio.ini
@@ -12,6 +12,7 @@
 
 # There should be only one env section for the DUT under test.
 # One of
+#	atmega168p
 #	atmega328p
 #   atmega2560_timer1
 #   atmega2560_timer3
@@ -28,4 +29,3 @@ board       = nanoatmega328
 framework   = arduino
 build_flags = -Werror -Wall ${common.build_flags}
 lib_extra_dirs = ../../../../..
-

--- a/extras/tests/simavr_based/test_seq_sd_07_328p/platformio.ini
+++ b/extras/tests/simavr_based/test_seq_sd_07_328p/platformio.ini
@@ -12,6 +12,7 @@
 
 # There should be only one env section for the DUT under test.
 # One of
+#	atmega168p
 #	atmega328p
 #   atmega2560_timer1
 #   atmega2560_timer3
@@ -28,4 +29,3 @@ board       = nanoatmega328
 framework   = arduino
 build_flags = -Werror -Wall ${common.build_flags}
 lib_extra_dirs = ../../../../..
-

--- a/extras/tests/simavr_based/test_seq_sd_11_328p/platformio.ini
+++ b/extras/tests/simavr_based/test_seq_sd_11_328p/platformio.ini
@@ -12,6 +12,7 @@
 
 # There should be only one env section for the DUT under test.
 # One of
+#	atmega168p
 #	atmega328p
 #   atmega2560_timer1
 #   atmega2560_timer3

--- a/src/AVRStepperPins.h
+++ b/src/AVRStepperPins.h
@@ -11,15 +11,17 @@
  */
 
 #if defined(ARDUINO_ARCH_AVR)
-#if !(defined(__AVR_ATmega328P__) || defined(__AVR_ATmega2560__) || \
-      defined(__AVR_ATmega32U4__))
+#if !(defined(__AVR_ATmega168__) || defined(__AVR_ATmega168P__) || \
+      defined(__AVR_ATmega328__) || defined(__AVR_ATmega328P__) || \
+      defined(__AVR_ATmega2560__) || defined(__AVR_ATmega32U4__))
 #error "Unsupported AVR derivate"
 #endif
 #endif
 
 // The ATmega328P has one 16 bit timer: Timer 1
 // The ATmega2560 has four 16 bit timers: Timer 1, 3, 4 and 5
-#if defined(__AVR_ATmega328P__)
+#if (defined(__AVR_ATmega168__) || defined(__AVR_ATmega168P__) || \
+     defined(__AVR_ATmega328__) || defined(__AVR_ATmega328P__))
 #define FAS_TIMER_MODULE 1
 #define stepPinStepper1A 9  /* OC1A */
 #define stepPinStepper1B 10 /* OC1B */

--- a/src/FastAccelStepper.h
+++ b/src/FastAccelStepper.h
@@ -8,7 +8,7 @@
 //
 // FastAccelStepper is a high speed alternative for the
 // [AccelStepper library](http://www.airspayce.com/mikem/arduino/AccelStepper/).
-// Supported are avr (ATmega 328, ATmega2560), esp32 and atmelsam due.
+// Supported are avr (ATmega 168/328/P, ATmega2560), esp32 and atmelsam due.
 //
 // Here is a basic example to run a stepper from position 0 to 1000 and back
 // again to 0.
@@ -96,14 +96,14 @@ class FastAccelStepperEngine {
   // Comments to valid pins:
   //
   // clang-format off
-  // | Device     | Comment                                                                                           |
-  // |:-----------|:--------------------------------------------------------------------------------------------------|
-  // | ESP32      | Every output capable GPIO can be used                                                             |
-  // | ESP32S2    | Every output capable GPIO can be used                                                             |
-  // | Atmega328p | Only the pins connected to OC1A and OC1B are allowed                                              |
-  // | Atmega2560 | Only the pins connected to OC4A, OC4B and OC4C are allowed.                                       |
-  // | Atmega32u4 | Only the pins connected to OC1A, OC1B and OC1C are allowed                                        |
-  // | Atmel SAM  | This can be one of each group of pins: 34/67/74/35, 17/36/72/37/42, 40/64/69/41, 9, 8/44, 7/45, 6 |
+  // | Device          | Comment                                                                                           |
+  // |:----------------|:--------------------------------------------------------------------------------------------------|
+  // | ESP32           | Every output capable GPIO can be used                                                             |
+  // | ESP32S2         | Every output capable GPIO can be used                                                             |
+  // | Atmega168/328/p | Only the pins connected to OC1A and OC1B are allowed                                              |
+  // | Atmega2560      | Only the pins connected to OC4A, OC4B and OC4C are allowed.                                       |
+  // | Atmega32u4      | Only the pins connected to OC1A, OC1B and OC1C are allowed                                        |
+  // | Atmel SAM       | This can be one of each group of pins: 34/67/74/35, 17/36/72/37/42, 40/64/69/41, 9, 8/44, 7/45, 6 |
   // clang-format on
 
   // ## External Pins

--- a/src/common.h
+++ b/src/common.h
@@ -362,10 +362,11 @@ struct queue_end_s {
 
 //==========================================================================
 //
-// AVR derivate ATmega 328P
+// AVR derivate ATmega 168/328/P
 //
 //==========================================================================
-#if defined(__AVR_ATmega328P__)
+#if (defined(__AVR_ATmega168__) || defined(__AVR_ATmega168P__) || \
+     defined(__AVR_ATmega328__) || defined(__AVR_ATmega328P__))
 #define SUPPORT_EXTERNAL_DIRECTION_PIN
 #define MAX_STEPPER 2
 #define NUM_QUEUES 2


### PR DESCRIPTION
This adds support for the ATmega168, ATmega168P, and ATmega328 (currently only the ATmega328P is supported). These are all identical except:
 - The 168 variants have smaller RAM/flash/EEPROM
 - The P variants are lower power
 - All variants are encoded/treated as separate MCUs requiring recompilation for each target

This also technically adds support for the ATmega168A and ATmega168PA, which appear as ATmega168 to the compiler.