### PR TITLE
Fix initialization of _stepper_cnt

### DIFF
--- a/src/FastAccelStepper.cpp
+++ b/src/FastAccelStepper.cpp
@@ -20,6 +20,7 @@ FastAccelStepper fas_stepper[MAX_STEPPER];
 //*************************************************************************************************
 void FastAccelStepperEngine::init() {
   _externalCallForPin = NULL;
+  _stepper_cnt = 0;
   fas_init_engine(this, 255);
   for (uint8_t i = 0; i < MAX_STEPPER; i++) {
     _stepper[i] = NULL;
@@ -29,6 +30,7 @@ void FastAccelStepperEngine::init() {
 #if defined(SUPPORT_CPU_AFFINITY)
 void FastAccelStepperEngine::init(uint8_t cpu_core) {
   _externalCallForPin = NULL;
+  _stepper_cnt = 0;
   fas_init_engine(this, cpu_core);
 }
 #endif


### PR DESCRIPTION
This was causing stepper initialization to randomly fail (on ESP32-S3) because sometimes `_stepper_cnt` was initialized to a non-zero value, and the check for `_stepper_cnt >= MAX_STEPPER` (in `stepperConnectToPin`) evaluated to true – even on the first stepper added.