### PR TITLE
Improve documentation for stepper_command_s

### DIFF
--- a/src/fas_common.h
+++ b/src/fas_common.h
@@ -8,14 +8,32 @@
 #define MOVE_ERR_SPEED_IS_UNDEFINED -2
 #define MOVE_ERR_ACCELERATION_IS_UNDEFINED -3
 
-//	ticks is multiplied by (1/TICKS_PER_S) in s
+// Low level stepper motor command.
 //	If steps is 0, then a pause is generated
+//
+// You can add these using the addQueueEntry method.
+// They will be executed sequentially until the queue runs out.
+//
+// There are some constraints on the values:
+// - `ticks` must be greater or equal to FastAccelStepper::getMaxSpeedInTicks.
+// - `ticks*steps` must be greater or equal to MIN_CMD_TICKS
 struct stepper_command_s {
+struct stepper_command_s {
+  // Number of ticks between each step.
+  //
+  // See TICKS_PER_S
   uint16_t ticks;
+  uint16_t ticks;
+  // Number of steps to send to the stepper motor during this command.
+  //
+  // If zero, then this command will be treated as a pause, lasting for a number of ticks given by `ticks`.
   uint8_t steps;
+  uint8_t steps;
+  // True if the direction pin should be high during this command, false if it should be low.
+  bool count_up;
   bool count_up;
 };
-
+};
 struct actual_ticks_s {
   uint32_t ticks;  // ticks == 0 means standstill
   bool count_up;


### PR DESCRIPTION
I spent the last 2 hours being confused about why my code didn't work, until I figured out that I had assumed that `ticks` was the total number of ticks in the command, not the spacing between the ticks. Hopefully, better documentation will ensure no other people fall into the same trap.