### PR TITLE
Only add ```cpp ... ``` for better code formatting

### DIFF
--- a/extras/doc/FastAccelStepper_API.md
+++ b/extras/doc/FastAccelStepper_API.md
@@ -6,7 +6,7 @@ Supported are avr (ATmega 168/328/P, ATmega2560), esp32 and atmelsam due.
 
 Here is a basic example to run a stepper from position 0 to 1000 and back
 again to 0.
-```
+```cpp
 
 FastAccelStepperEngine engine = FastAccelStepperEngine();
 FastAccelStepper *stepper = NULL;


### PR DESCRIPTION
In [FastAccelStepper_API.md](extras/doc/FastAccelStepper_API.md), I noticed that the code block was not formatted like the others:
```

FastAccelStepperEngine engine = FastAccelStepperEngine();
FastAccelStepper *stepper = NULL;

#define dirPinStepper    5
#define enablePinStepper 6
#define stepPinStepper   9
void setup() {
   engine.init();
   stepper = engine.stepperConnectToPin(stepPinStepper);
   if (stepper) {
      stepper->setDirectionPin(dirPinStepper);
      stepper->setEnablePin(enablePinStepper);
      stepper->setAutoEnable(true);

      stepper->setSpeedInHz(500);
      stepper->setAcceleration(100);
      stepper->moveTo(1000, true);
      stepper->moveTo(0, true);
   }
}

void loop() {}
```
To improve consistency and readability, I suggest adding cpp for syntax highlighting:
```cpp

FastAccelStepperEngine engine = FastAccelStepperEngine();
FastAccelStepper *stepper = NULL;

#define dirPinStepper    5
#define enablePinStepper 6
#define stepPinStepper   9
void setup() {
   engine.init();
   stepper = engine.stepperConnectToPin(stepPinStepper);
   if (stepper) {
      stepper->setDirectionPin(dirPinStepper);
      stepper->setEnablePin(enablePinStepper);
      stepper->setAutoEnable(true);

      stepper->setSpeedInHz(500);
      stepper->setAcceleration(100);
      stepper->moveTo(1000, true);
      stepper->moveTo(0, true);
   }
}

void loop() {}
```

I didn’t find any contributing guidelines in the [Community Standards](https://github.com/gin66/FastAccelStepper/community),
so I wrote this pull request quickly. Let me know if any adjustments are needed!