### PR TITLE
Fix assertion on ESP32 S3 with IDF v5.4

### DIFF
--- a/src/StepperISR_idf5_esp32_rmt.cpp
+++ b/src/StepperISR_idf5_esp32_rmt.cpp
@@ -226,7 +226,7 @@ void StepperQueue::init_rmt(uint8_t channel_num, uint8_t step_pin) {
 }
 
 void StepperQueue::connect_rmt() {
-  rmt_tx_channel_config_t config;
+  rmt_tx_channel_config_t config{};
   config.gpio_num = (gpio_num_t)_step_pin;
   config.clk_src = RMT_CLK_SRC_DEFAULT;
   config.resolution_hz = TICKS_PER_S;


### PR DESCRIPTION
Some ESP32 boards don't support `SOC_RMT_SUPPORT_SLEEP_RETENTION`. As a result, I can't execute app with FastAccelStepper on my environment without additional changes due to assertion:

https://github.com/espressif/esp-idf/blob/master/components/esp_driver_rmt/src/rmt_tx.c#L269

Beause for some reason `allow_pd` is always initialized to 1 for me

Simply setting it to 0 is problematic, due to renaming: https://github.com/espressif/esp-idf/commit/491901d7e472bb2510b488c40e5f6bcd090013bd

Therefore, it remains to set all fields of `rmt_rx_channel_config_t` to 0. This can be done either by initializing through empty curly braces (since C++11) or using `memset`