### PR TITLE
clear PIN_EXTERNAL_FLAG before PCNT channel config

### DIFF
--- a/src/FastAccelStepper.h
+++ b/src/FastAccelStepper.h
@@ -795,14 +795,16 @@ class FastAccelStepper {
 #if defined(SUPPORT_ESP32_PULSE_COUNTER) && (ESP_IDF_VERSION_MAJOR == 5)
   bool attachToPulseCounter(uint8_t unused_pcnt_unit = 0,
                             int16_t low_value = -16384,
-                            int16_t high_value = 16384);
+                            int16_t high_value = 16384,
+                            uint8_t dir_pin_readback = PIN_UNDEFINED);
   int16_t readPulseCounter();
   void clearPulseCounter();
   inline bool pulseCounterAttached() { return _attached_pulse_unit != NULL; }
 #endif
 #if defined(SUPPORT_ESP32_PULSE_COUNTER) && (ESP_IDF_VERSION_MAJOR == 4)
   bool attachToPulseCounter(uint8_t pcnt_unit, int16_t low_value = -16384,
-                            int16_t high_value = 16384);
+                            int16_t high_value = 16384,
+                            uint8_t dir_pin_readback = PIN_UNDEFINED);
   int16_t readPulseCounter();
   void clearPulseCounter();
   inline bool pulseCounterAttached() { return _attached_pulse_cnt_unit >= 0; }

--- a/src/FastAccelStepper_idf4_esp32_pcnt.cpp
+++ b/src/FastAccelStepper_idf4_esp32_pcnt.cpp
@@ -28,8 +28,11 @@ bool FastAccelStepper::attachToPulseCounter(uint8_t pcnt_unit,
 
   pcnt_config_t cfg;
   uint8_t step_pin = getStepPin();
-  cfg.pulse_gpio_num = PCNT_PIN_NOT_USED;
   if (dir_pin == PIN_UNDEFINED) {
+    dir_pin = getDirectionPin();
+  }
+  cfg.pulse_gpio_num = PCNT_PIN_NOT_USED;
+  if (dir_pin == PIN_UNDEFINED || (dir_pin & PIN_EXTERNAL_FLAG) != 0) {
     cfg.ctrl_gpio_num = PCNT_PIN_NOT_USED;
     cfg.hctrl_mode = PCNT_MODE_KEEP;
     cfg.lctrl_mode = PCNT_MODE_KEEP;
@@ -64,7 +67,7 @@ bool FastAccelStepper::attachToPulseCounter(uint8_t pcnt_unit,
   gpio_matrix_in(step_pin, sig_idx[pcnt_unit], 0);
   gpio_iomux_in(step_pin,
                 sig_idx[pcnt_unit]);  // test failure without this call
-  if (dir_pin != PIN_UNDEFINED) {
+  if (dir_pin != PIN_UNDEFINED && (dir_pin & PIN_EXTERNAL_FLAG) == 0) {
     pinMode(dir_pin, OUTPUT);
     gpio_matrix_out(dir_pin, 0x100, false, false);
     gpio_matrix_in(dir_pin, ctrl_idx[pcnt_unit], 0);

--- a/src/FastAccelStepper_idf4_esp32_pcnt.cpp
+++ b/src/FastAccelStepper_idf4_esp32_pcnt.cpp
@@ -20,13 +20,13 @@ uint32_t ctrl_idx[SUPPORT_ESP32_PULSE_COUNTER] = {
 
 bool FastAccelStepper::attachToPulseCounter(uint8_t pcnt_unit,
                                             int16_t low_value,
-                                            int16_t high_value) {
+                                            int16_t high_value,
+                                            uint8_t dir_pin) {
   if (pcnt_unit >= SUPPORT_ESP32_PULSE_COUNTER) {
     return false;
   }
 
   pcnt_config_t cfg;
-  uint8_t dir_pin = getDirectionPin() & ~PIN_EXTERNAL_FLAG;;
   uint8_t step_pin = getStepPin();
   cfg.pulse_gpio_num = PCNT_PIN_NOT_USED;
   if (dir_pin == PIN_UNDEFINED) {

--- a/src/FastAccelStepper_idf4_esp32_pcnt.cpp
+++ b/src/FastAccelStepper_idf4_esp32_pcnt.cpp
@@ -26,7 +26,7 @@ bool FastAccelStepper::attachToPulseCounter(uint8_t pcnt_unit,
   }
 
   pcnt_config_t cfg;
-  uint8_t dir_pin = getDirectionPin();
+  uint8_t dir_pin = getDirectionPin() & ~PIN_EXTERNAL_FLAG;;
   uint8_t step_pin = getStepPin();
   cfg.pulse_gpio_num = PCNT_PIN_NOT_USED;
   if (dir_pin == PIN_UNDEFINED) {

--- a/src/FastAccelStepper_idf5_esp32_pcnt.cpp
+++ b/src/FastAccelStepper_idf5_esp32_pcnt.cpp
@@ -44,7 +44,7 @@ bool FastAccelStepper::attachToPulseCounter(uint8_t unused_pcnt_unit,
 
   pcnt_channel_level_action_t level_high = PCNT_CHANNEL_LEVEL_ACTION_KEEP;
   pcnt_channel_level_action_t level_low = PCNT_CHANNEL_LEVEL_ACTION_KEEP;
-  uint8_t dir_pin = getDirectionPin();
+  uint8_t dir_pin = getDirectionPin() & ~PIN_EXTERNAL_FLAG;
   if (dir_pin != PIN_UNDEFINED) {
     chan_config.level_gpio_num = dir_pin;
     if (directionPinHighCountsUp()) {

--- a/src/FastAccelStepper_idf5_esp32_pcnt.cpp
+++ b/src/FastAccelStepper_idf5_esp32_pcnt.cpp
@@ -46,7 +46,11 @@ bool FastAccelStepper::attachToPulseCounter(uint8_t unused_pcnt_unit,
   pcnt_channel_level_action_t level_high = PCNT_CHANNEL_LEVEL_ACTION_KEEP;
   pcnt_channel_level_action_t level_low = PCNT_CHANNEL_LEVEL_ACTION_KEEP;
 
-  if (dir_pin != PIN_UNDEFINED) {
+  if (dir_pin == PIN_UNDEFINED) {
+    dir_pin = getDirectionPin();
+  }
+
+  if (dir_pin != PIN_UNDEFINED && (dir_pin & PIN_EXTERNAL_FLAG) == 0) {
     chan_config.level_gpio_num = dir_pin;
     if (directionPinHighCountsUp()) {
       level_low = PCNT_CHANNEL_LEVEL_ACTION_INVERSE;
@@ -106,7 +110,7 @@ bool FastAccelStepper::attachToPulseCounter(uint8_t unused_pcnt_unit,
                    .pulse_sig;
   gpio_matrix_in(step_pin, signal, 0);
   gpio_iomux_in(step_pin, signal);
-  if (dir_pin != PIN_UNDEFINED) {
+  if (dir_pin != PIN_UNDEFINED && (dir_pin & PIN_EXTERNAL_FLAG) == 0) {
     pinMode(dir_pin, OUTPUT);
     int control = pcnt_periph_signals.groups[0]
                       .units[unit_id]

--- a/src/FastAccelStepper_idf5_esp32_pcnt.cpp
+++ b/src/FastAccelStepper_idf5_esp32_pcnt.cpp
@@ -20,7 +20,8 @@ struct pcnt_chan_t {
 
 bool FastAccelStepper::attachToPulseCounter(uint8_t unused_pcnt_unit,
                                             int16_t low_value,
-                                            int16_t high_value) {
+                                            int16_t high_value,
+                                            uint8_t dir_pin) {
   pcnt_unit_config_t config = {.low_limit = low_value,
                                .high_limit = high_value,
                                .intr_priority = 0,
@@ -44,7 +45,7 @@ bool FastAccelStepper::attachToPulseCounter(uint8_t unused_pcnt_unit,
 
   pcnt_channel_level_action_t level_high = PCNT_CHANNEL_LEVEL_ACTION_KEEP;
   pcnt_channel_level_action_t level_low = PCNT_CHANNEL_LEVEL_ACTION_KEEP;
-  uint8_t dir_pin = getDirectionPin() & ~PIN_EXTERNAL_FLAG;
+
   if (dir_pin != PIN_UNDEFINED) {
     chan_config.level_gpio_num = dir_pin;
     if (directionPinHighCountsUp()) {


### PR DESCRIPTION
In my case I need to do some extra actions with direction change, so I use mcu dir_pin with external flag. But in that case the PCNT module gets "wrong" direction pin from getDirectionPin() and the pin freezes in its state.
Took some time to determine why pin freezes.
So external flag clearing solves the problem.
(tested on IDF5 but assume that IDF4 has the same problem)