### PR TITLE
samx3-due: Fix null result from tryAllocateQueue()

### DIFF
--- a/src/pd_sam/sam_queue.h
+++ b/src/pd_sam/sam_queue.h
@@ -8,7 +8,7 @@ class StepperQueue : public StepperQueueBase {
  public:
 #include "../fas_queue/protocol.h"
 
-  uint8_t _step_pin;
+  uint8_t _step_pin = PIN_UNDEFINED;
   uint8_t _queue_num;
   void* driver_data;
   volatile bool _hasISRactive;


### PR DESCRIPTION
When attempting to run `stepperConnectToPin()` on Arduino Due (SAM3X), a `null` result is returned.
In `sam_queue.cpp`: `tryAllocateQueue()`:
The function can only return a valid result `if (fas_queue[i]._step_pin == PIN_UNDEFINED)` (i.e. the pin is unallocated)

Since _step_pin is initialised by default as `0` on Due, compared to `PIN_UNDEFINED = 255`, `tryAllocateQueue()` returns `null`

Proposed Fix: Update definition in `sam_queue.h` of the class `StepperQueue` to explicitly initialise `_step_pin` as `PIN_UNDEFINED`:

`uint8_t _step_pin = PIN_UNDEFINED; `

Tested as working on Arduino Due hardware using PlatformIO