### PR TITLE
Fix ESP-IDF 6 RMT header include

### DIFF
--- a/src/pd_esp32/pd_config_idf6.h
+++ b/src/pd_esp32/pd_config_idf6.h
@@ -155,7 +155,12 @@
 
 #ifdef NEED_RMT_HEADERS
 #include <driver/rmt_tx.h>
+#include <esp_idf_version.h>
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+#include <hal/rmt_periph.h>
+#else
 #include <soc/rmt_periph.h>
+#endif
 #include <soc/rmt_reg.h>
 #include <soc/rmt_struct.h>
 


### PR DESCRIPTION
Fix for #365 

This should preserve existing ESP-IDF 5.x behavior while fixing builds on ESP-IDF 6.x.

The patch was tested in an ESP-IDF 6.0.1 project targeting ESP32-S3